### PR TITLE
Some practical improvements

### DIFF
--- a/hck.sh
+++ b/hck.sh
@@ -32,7 +32,7 @@ then
   exit
 fi
 
-if test x`whoami` != xroot
+if [ "$USER" != root ]
 then
   echo This script must be run as superuser
   exit 1

--- a/hck.sh
+++ b/hck.sh
@@ -147,7 +147,6 @@ kill_jobs() {
 
 make_bridge_script() {
 SCRIPTFILE="${HCK_ROOT}"/$1
-REAL_ME=`logname`
 cat <<EOF > ${SCRIPTFILE}
 #!/bin/sh
 . ${CONFIG_FILE}

--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -35,6 +35,14 @@ timestamp()
     echo `date -u +'%Y-%m-%dT%H-%M-%SZ'`
 }
 
+# Real user
+REAL_ME=$USER
+if [ -n "$SUDO_USER" ]
+then
+    REAL_ME=$SUDO_USER
+    [ "$RUN_QEMU_AS_ROOT" = true ] && QEMU_RUN_AS="-runas ${REAL_ME}"
+fi
+
 STUDIO_IMAGE=`readlink -f $STUDIO_IMAGE`
 CLIENT1_IMAGE=`readlink -f $CLIENT1_IMAGE`
 CLIENT2_IMAGE=`readlink -f $CLIENT2_IMAGE`

--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -130,6 +130,47 @@ then
    SHARE_ON_HOST="false"
 fi
 
+set_qcow2_l2_cache() {
+    [ "$USE_FULL_QCOW2_L2_CACHE" = true ] || return 0
+    local L2_DEFAULT_CLUSTERS=8
+    local L2_DEFAULT_SIZE=1048576
+    # Format, virtual size, cluster size:
+    set $(${QEMU_IMG_BIN} info $1 |
+          egrep 'file format|virtual size|cluster_size' |
+          sed 's/(//;s/ bytes)//' |
+          awk '{print $NF}')
+    if [ "$1" = qcow2 ]
+    then
+        # size*cache_clusters/cluster_size, but divisible by cluster_size:
+        local L2SIZE=$(( $2 * $L2_DEFAULT_CLUSTERS / $3**2 * $3 ))
+        # Apply only if not smaller than the default
+        [ $L2SIZE -gt $L2_DEFAULT_SIZE ] && printf ",l2-cache-size=%s" $L2SIZE
+    fi
+}
+
+### Same thing without qemu-img:
+#set_qcow2_l2_cache() {
+#    [ "$USE_FULL_QCOW2_L2_CACHE" = true ] || return 0
+#    local L2_DEFAULT_CLUSTERS=8
+#    local L2_DEFAULT_SIZE=1048576
+#    # Info: http://git.qemu.org/?p=qemu.git;a=blob;f=docs/specs/qcow2.txt
+#    set $(od -N 32 --endian=big -An -x $1 2> /dev/null | tr -d " ")
+#    local MAG_VER=$(cut -c 1-16 <<< $1)
+#    case $MAG_VER in
+#    514649fb0000000[2-3])
+#        # File is qcow2
+#        local CLUSTERBITS=$(cut -c 9-16 <<< $2)
+#        local CLUSTERSIZE=$(( 1 << 0x$CLUSTERBITS ))
+#        local DRIVESIZE=$(cut -c 17-32 <<< $2)
+#        # size*cache_clusters/cluster_size, but divisible by cluster_size:
+#        # Info: http://git.qemu.org/?p=qemu.git;a=blob;f=docs/qcow2-cache.txt
+#        local L2SIZE=$(( 0x$DRIVESIZE * $L2_DEFAULT_CLUSTERS /
+#                         $CLUSTERSIZE**2 * $CLUSTERSIZE ))
+#        # Apply only if not smaller than the default
+#        [ $L2SIZE -gt $L2_DEFAULT_SIZE ] && printf ",l2-cache-size=%s" $L2SIZE
+#    esac
+#}
+
 remove_bridges() {
   case $TEST_NET_TYPE in
   bridge)

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -88,6 +88,11 @@ STUDIO_IMAGE=${IMAGES_DIR}/HCK_Studio_WS2008R2_SP1.qcow2
 CLIENT1_IMAGE=${IMAGES_DIR}/HCK_Client1_WS2008R2_SP1.qcow2
 CLIENT2_IMAGE=${IMAGES_DIR}/HCK_Client2_WS2008R2_SP1.qcow2
 
+# Use sufficient QCOW2 L2 cache to cover the entire virtual size of the image.
+# Setting this to "true" can increase the performance significantly.
+# More details on this: https://git.qemu.org/?p=qemu.git;a=blob;f=docs/qcow2-cache.txt
+USE_FULL_QCOW2_L2_CACHE=false
+
 #CDROM options for clients
 #CDROM_CLIENT="/non/existing/path/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso"
 CDROM_CLIENT1=$CDROM_CLIENT

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -119,6 +119,8 @@ CLIENT_WORLD_ACCESS=off  # Turn on ONLY for activation purposes!
 VHOST_STATE=on
 SNAPSHOT=off
 ENLIGHTENMENTS_STATE=off
+#OPT_CPU_FLAGS=",+ssse3,+sse4.1,+sse4.2"  # Optional extra flags for CPU
+VCPU_MODEL=13  # For example: 13 = Dothan, 26 = Nehalem, 58 = IvyBridge
 ENABLE_S3=on
 ENABLE_S4=on
 #BIOS may be required if S3/S4 supported

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -25,6 +25,7 @@ HCK_ROOT=`dirname $0`
 
 #QEMU PATH
 QEMU_BIN=/usr/libexec/qemu-kvm
+QEMU_IMG_BIN=qemu-img
 
 #IVSHMEM SERVER PATH
 IVSHMEM_SERVER_BIN=ivshmem-server

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -14,6 +14,12 @@
 #Setup ID
 UNIQUE_ID=11  # 1 ... 9999
 
+# Run QEMU process as root (note: VirtHCK should ALWAYS be started with root
+# privileges. Setting this option to "false" will just make the process drop
+# the root privileges once running, if started via sudo).
+# "false" is recommended! The default is "true" for backward compatibility.
+RUN_QEMU_AS_ROOT=true
+
 #HCK root
 HCK_ROOT=`dirname $0`
 

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -367,7 +367,7 @@ ${QEMU_BIN} \
         -machine ${MACHINE_TYPE} \
         -nodefaults -nodefconfig \
         -m `client_memory` -smp `client_cpus`,cores=`client_cpus` -enable-kvm \
-        -cpu qemu64,+x2apic,+fsgsbase,model=13${ENLIGHTENMENTS_OPTION} \
+        -cpu qemu64,+x2apic,+fsgsbase${OPT_CPU_FLAGS},model=${VCPU_MODEL}${ENLIGHTENMENTS_OPTION} \
         -usb -device usb-tablet -boot ${BOOT_ORDER} \
         -rtc-td-hack -global kvm-pit.lost_tick_policy=discard -rtc base=localtime,clock=host,driftfix=slew \
         -global ${DISABLE_S3_PARAM}=${S3_DISABLE_OPTION} -global ${DISABLE_S4_PARAM}=${S4_DISABLE_OPTION} \

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -210,7 +210,7 @@ prepare_test_image()
   local TEST_IMAGE_NAME=`test_image_name ${IMAGE_NUM}`
 
   test -f ${TEST_IMAGE_NAME} || \
-  { echo Creating test image of ${TEST_IMAGE_SIZE} ${TEST_IMAGE_NAME}...; qemu-img create -f qcow2 ${TEST_IMAGE_NAME} ${TEST_IMAGE_SIZE}; }
+  { echo Creating test image of ${TEST_IMAGE_SIZE} ${TEST_IMAGE_NAME}...; ${QEMU_IMG_BIN} create -f qcow2 ${TEST_IMAGE_NAME} ${TEST_IMAGE_SIZE}; }
 }
 
 if [ x"${CLIENT_WORLD_ACCESS}" = xon ]; then

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -218,7 +218,7 @@ if [ x"${CLIENT_WORLD_ACCESS}" = xon ]; then
                      -device ${WORLD_NET_DEVICE},netdev=hostnet9,mac=22:11:11:0${CLIENT_NUM}:${UID_FIRST}:${UID_SECOND},id=tmp_${UNIQUE_ID}_${CLIENT_NUM}"
 fi
 
-IDE_STORAGE_PAIR="-drive file=`image_name`,if=none,id=ide_${UNIQUE_ID}_${CLIENT_NUM}${DRIVE_CACHE_OPTION}
+IDE_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=ide_${UNIQUE_ID}_${CLIENT_NUM}${DRIVE_CACHE_OPTION}
                   -device ide-hd,drive=ide_${UNIQUE_ID}_${CLIENT_NUM},serial=${CLIENT_NUM}1${UNIQUE_ID}"
 
 if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
@@ -250,25 +250,25 @@ if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
                          -device ${TEST_DEV_NAME}`extra_params_cmd`,netdev=hostnet2,mac=${TEST_NET_MAC_ADDRESS},bus=${BUS_NAME}.0$(client_mq_device_param)${TEST_DEVICE_ID}"
        ;;
     bootstorage)
-       BOOT_STORAGE_PAIR="-drive file=`image_name`,if=none,id=vio_block${DRIVE_CACHE_OPTION}
+       BOOT_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=vio_block${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=vio_block,serial=${CLIENT_NUM}1${UNIQUE_ID}"
        ;;
     storage-blk)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=virtio_blk${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=virtio_blk${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=virtio_blk,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
        ;;
     storage-scsi)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=virtio_scsi${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=virtio_scsi${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,id=scsi,bus=${BUS_NAME}.0,addr=0x5
                           -device scsi-hd,drive=virtio_scsi,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
        ;;
     fs-filter)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=fs_filter${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=fs_filter${DRIVE_CACHE_OPTION}
                           -device ide-hd,drive=fs_filter,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
        ;;

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -351,6 +351,7 @@ CTRL_NET_DEVICE="-netdev tap,id=hostnet0,script=${HCK_ROOT}/hck_ctrl_bridge_ifup
                  -device ${CTRL_NET_DEVICE},netdev=hostnet0,mac=`client_ctrl_mac`,bus=${CTRL_BUS_NAME}.0,id=`client_ctrl_ifname`"
 
 ${QEMU_BIN} \
+        ${QEMU_RUN_AS} \
         ${BOOT_STORAGE_PAIR} \
         ${TEST_STORAGE_PAIR} \
         ${CTRL_NET_DEVICE} \

--- a/run_hck_studio.sh
+++ b/run_hck_studio.sh
@@ -38,6 +38,7 @@ STUDIO_UUID="-uuid ${UNIQUE_ID}127c-8795-4e67-95da-8dd0a8891cd1"
 fi
 
 ${QEMU_BIN} \
+    ${QEMU_RUN_AS} \
     -drive file=${STUDIO_IMAGE},if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
     -device ide-hd,drive=ide_${UNIQUE_ID},serial=${UID_FIRST}${UNIQUE_ID} \
     ${WORLD_NET_DEVICE} \

--- a/run_hck_studio.sh
+++ b/run_hck_studio.sh
@@ -39,7 +39,7 @@ fi
 
 ${QEMU_BIN} \
     ${QEMU_RUN_AS} \
-    -drive file=${STUDIO_IMAGE},if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
+    -drive file=${STUDIO_IMAGE}$(set_qcow2_l2_cache ${STUDIO_IMAGE}),if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
     -device ide-hd,drive=ide_${UNIQUE_ID},serial=${UID_FIRST}${UNIQUE_ID} \
     ${WORLD_NET_DEVICE} \
     ${CTRL_NET_DEVICE} \

--- a/run_hck_studio.sh
+++ b/run_hck_studio.sh
@@ -44,7 +44,8 @@ ${QEMU_BIN} \
     ${WORLD_NET_DEVICE} \
     ${CTRL_NET_DEVICE} \
     ${FILE_TRANSFER_SETUP} \
-    -m 2G -smp 1 -enable-kvm -cpu qemu64,+x2apic,+fsgsbase -usb -device usb-tablet \
+    -m 2G -smp 1 -enable-kvm -usb -device usb-tablet \
+    -cpu qemu64,+x2apic,+fsgsbase${OPT_CPU_FLAGS} \
     ${STUDIO_UUID} \
     -name HCK-Studio_${UNIQUE_ID}_`hostname`_${TITLE_POSTFIX} \
     -rtc base=localtime \


### PR DESCRIPTION
It's no secret that VirtHCK is a very convenient tool for launching VMs, even without any relation to HCK tests. I used it to launch my Linux VMs for data processing purposes, until I wrote something more specialized for my needs. Parts of it (which are not connected to the more specific work) are available on [GitHub](https://github.com/blochl/pVM).

I used VirtHCK as a reference for several aspects, and I would like to send a few patches back that you may find useful for your needs. I did not test these on an actual VirtHCK setup, but with my scripts this works nicely.

I remember that having more than 2 VirtHCK setups on a server was beginning to be painful, more than 4 - impossible. I wonder if these patches (specifically using a sufficient L2 cache for qcow2 images and exposing some SIMD instructions of the CPU) can improve that. Also, running processes that do not require to be run as root, as a non-root is a good security practice.

Best regards,
Leonid.