### PR TITLE
Revert "Make an option to use a sufficient L2 cache for QCOW2 images"

### DIFF
--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -88,11 +88,6 @@ STUDIO_IMAGE=${IMAGES_DIR}/HCK_Studio_WS2008R2_SP1.qcow2
 CLIENT1_IMAGE=${IMAGES_DIR}/HCK_Client1_WS2008R2_SP1.qcow2
 CLIENT2_IMAGE=${IMAGES_DIR}/HCK_Client2_WS2008R2_SP1.qcow2
 
-# Use sufficient QCOW2 L2 cache to cover the entire virtual size of the image.
-# Setting this to "true" can increase the performance significantly.
-# More details on this: https://git.qemu.org/?p=qemu.git;a=blob;f=docs/qcow2-cache.txt
-USE_FULL_QCOW2_L2_CACHE=false
-
 #CDROM options for clients
 #CDROM_CLIENT="/non/existing/path/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso"
 CDROM_CLIENT1=$CDROM_CLIENT

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -218,7 +218,7 @@ if [ x"${CLIENT_WORLD_ACCESS}" = xon ]; then
                      -device ${WORLD_NET_DEVICE},netdev=hostnet9,mac=22:11:11:0${CLIENT_NUM}:${UID_FIRST}:${UID_SECOND},id=tmp_${UNIQUE_ID}_${CLIENT_NUM}"
 fi
 
-IDE_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=ide_${UNIQUE_ID}_${CLIENT_NUM}${DRIVE_CACHE_OPTION}
+IDE_STORAGE_PAIR="-drive file=`image_name`,if=none,id=ide_${UNIQUE_ID}_${CLIENT_NUM}${DRIVE_CACHE_OPTION}
                   -device ide-hd,drive=ide_${UNIQUE_ID}_${CLIENT_NUM},serial=${CLIENT_NUM}1${UNIQUE_ID}"
 
 if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
@@ -250,25 +250,25 @@ if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
                          -device ${TEST_DEV_NAME}`extra_params_cmd`,netdev=hostnet2,mac=${TEST_NET_MAC_ADDRESS},bus=${BUS_NAME}.0$(client_mq_device_param)${TEST_DEVICE_ID}"
        ;;
     bootstorage)
-       BOOT_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=vio_block${DRIVE_CACHE_OPTION}
+       BOOT_STORAGE_PAIR="-drive file=`image_name`,if=none,id=vio_block${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=vio_block,serial=${CLIENT_NUM}1${UNIQUE_ID}"
        ;;
     storage-blk)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=virtio_blk${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=virtio_blk${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=virtio_blk,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
        ;;
     storage-scsi)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=virtio_scsi${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=virtio_scsi${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,id=scsi,bus=${BUS_NAME}.0,addr=0x5
                           -device scsi-hd,drive=virtio_scsi,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
        ;;
     fs-filter)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=fs_filter${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=fs_filter${DRIVE_CACHE_OPTION}
                           -device ide-hd,drive=fs_filter,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
        ;;

--- a/run_hck_studio.sh
+++ b/run_hck_studio.sh
@@ -39,7 +39,7 @@ fi
 
 ${QEMU_BIN} \
     ${QEMU_RUN_AS} \
-    -drive file=${STUDIO_IMAGE}$(set_qcow2_l2_cache ${STUDIO_IMAGE}),if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
+    -drive file=${STUDIO_IMAGE},if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
     -device ide-hd,drive=ide_${UNIQUE_ID},serial=${UID_FIRST}${UNIQUE_ID} \
     ${WORLD_NET_DEVICE} \
     ${CTRL_NET_DEVICE} \


### PR DESCRIPTION
there is an issue with runnig test images, reverting until figured out.

This reverts commit 31df3a166104f77aa0c65878c73bf8f39729085f.