### PR TITLE
Make an option to use a sufficient L2 cache for QCOW2 images [V2]

### DIFF
--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -130,6 +130,47 @@ then
    SHARE_ON_HOST="false"
 fi
 
+set_qcow2_l2_cache() {
+    [ "$USE_FULL_QCOW2_L2_CACHE" = true ] || return 0
+    local L2_DEFAULT_CLUSTERS=8
+    local L2_DEFAULT_SIZE=1048576
+    # Format, virtual size, cluster size:
+    set $(${QEMU_IMG_BIN} info $1 |
+          egrep 'file format|virtual size|cluster_size' |
+          sed 's/(//;s/ bytes)//' |
+          awk '{print $NF}')
+    if [ "$1" = qcow2 ]
+    then
+        # size*cache_clusters/cluster_size, but divisible by cluster_size:
+        local L2SIZE=$(( $2 * $L2_DEFAULT_CLUSTERS / $3**2 * $3 ))
+        # Apply only if not smaller than the default
+        [ $L2SIZE -gt $L2_DEFAULT_SIZE ] && printf ",l2-cache-size=%s" $L2SIZE
+    fi
+}
+
+### Same thing without qemu-img:
+#set_qcow2_l2_cache() {
+#    [ "$USE_FULL_QCOW2_L2_CACHE" = true ] || return 0
+#    local L2_DEFAULT_CLUSTERS=8
+#    local L2_DEFAULT_SIZE=1048576
+#    # Info: http://git.qemu.org/?p=qemu.git;a=blob;f=docs/specs/qcow2.txt
+#    set $(od -N 32 --endian=big -An -x $1 2> /dev/null | tr -d " ")
+#    local MAG_VER=$(cut -c 1-16 <<< $1)
+#    case $MAG_VER in
+#    514649fb0000000[2-3])
+#        # File is qcow2
+#        local CLUSTERBITS=$(cut -c 9-16 <<< $2)
+#        local CLUSTERSIZE=$(( 1 << 0x$CLUSTERBITS ))
+#        local DRIVESIZE=$(cut -c 17-32 <<< $2)
+#        # size*cache_clusters/cluster_size, but divisible by cluster_size:
+#        # Info: http://git.qemu.org/?p=qemu.git;a=blob;f=docs/qcow2-cache.txt
+#        local L2SIZE=$(( 0x$DRIVESIZE * $L2_DEFAULT_CLUSTERS /
+#                         $CLUSTERSIZE**2 * $CLUSTERSIZE ))
+#        # Apply only if not smaller than the default
+#        [ $L2SIZE -gt $L2_DEFAULT_SIZE ] && printf ",l2-cache-size=%s" $L2SIZE
+#    esac
+#}
+
 remove_bridges() {
   case $TEST_NET_TYPE in
   bridge)

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -93,6 +93,11 @@ CLIENT2_IMAGE=${IMAGES_DIR}/HCK_Client2_WS2008R2_SP1.qcow2
 # otherwise it will be create a new unpartition one
 FILESYSTEM_TESTS_IMAGE=${IMAGES_DIR}/filesystem_tests_image.qcow2
 
+# Use sufficient QCOW2 L2 cache to cover the entire virtual size of the image.
+# Setting this to "true" can increase the performance significantly.
+# More details on this: https://git.qemu.org/?p=qemu.git;a=blob;f=docs/qcow2-cache.txt
+USE_FULL_QCOW2_L2_CACHE=false
+
 #CDROM options for clients
 #CDROM_CLIENT="/non/existing/path/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso"
 CDROM_CLIENT1=$CDROM_CLIENT

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -88,9 +88,9 @@ STUDIO_IMAGE=${IMAGES_DIR}/HCK_Studio_WS2008R2_SP1.qcow2
 CLIENT1_IMAGE=${IMAGES_DIR}/HCK_Client1_WS2008R2_SP1.qcow2
 CLIENT2_IMAGE=${IMAGES_DIR}/HCK_Client2_WS2008R2_SP1.qcow2
 
-#File System Testing Prerequisites image
-# If parameted defined and exists, the image will be copied from here,
-# otherwise it will be create a new unpartition one
+# File System Testing Prerequisites image
+# If this parameter is defined and the file exists, the test image will be
+# copied from it. Otherwise, a new unpartitioned image will be created.
 FILESYSTEM_TESTS_IMAGE=${IMAGES_DIR}/filesystem_tests_image.qcow2
 
 # Use sufficient QCOW2 L2 cache to cover the entire virtual size of the image.

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -227,7 +227,7 @@ if [ x"${CLIENT_WORLD_ACCESS}" = xon ]; then
                      -device ${WORLD_NET_DEVICE},netdev=hostnet9,mac=22:11:11:0${CLIENT_NUM}:${UID_FIRST}:${UID_SECOND},id=tmp_${UNIQUE_ID}_${CLIENT_NUM}"
 fi
 
-IDE_STORAGE_PAIR="-drive file=`image_name`,if=none,id=ide_${UNIQUE_ID}_${CLIENT_NUM}${DRIVE_CACHE_OPTION}
+IDE_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=ide_${UNIQUE_ID}_${CLIENT_NUM}${DRIVE_CACHE_OPTION}
                   -device ide-hd,drive=ide_${UNIQUE_ID}_${CLIENT_NUM},serial=${CLIENT_NUM}1${UNIQUE_ID}"
 
 if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
@@ -259,27 +259,27 @@ if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
                          -device ${TEST_DEV_NAME}`extra_params_cmd`,netdev=hostnet2,mac=${TEST_NET_MAC_ADDRESS},bus=${BUS_NAME}.0$(client_mq_device_param)${TEST_DEVICE_ID}"
        ;;
     bootstorage)
-       BOOT_STORAGE_PAIR="-drive file=`image_name`,if=none,id=vio_block${DRIVE_CACHE_OPTION}
+       BOOT_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=vio_block${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=vio_block,serial=${CLIENT_NUM}1${UNIQUE_ID}"
        ;;
     storage-blk)
-       BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=virtio_blk${DRIVE_CACHE_OPTION}
-                          -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=virtio_blk,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
+       BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=virtio_blk${DRIVE_CACHE_OPTION}
+                          -device ${TEST_DEV_NAME}`extra_params_cmd`,bus=${BUS_NAME}.0,addr=0x5,drive=virtio_blk,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        ;;
     storage-scsi)
+       prepare_test_image 1
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=virtio_scsi${DRIVE_CACHE_OPTION}
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=virtio_scsi${DRIVE_CACHE_OPTION}
                           -device ${TEST_DEV_NAME}`extra_params_cmd`,id=scsi,bus=${BUS_NAME}.0,addr=0x5
                           -device scsi-hd,drive=virtio_scsi,serial=${CLIENT_NUM}0${UNIQUE_ID}"
-       prepare_test_image 1
        ;;
     fs-filter)
-       BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
-       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`,if=none,format=qcow2,id=fs_filter${DRIVE_CACHE_OPTION}
-                          -device ide-hd,drive=fs_filter,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        prepare_test_image 1
+       BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
+       TEST_STORAGE_PAIR="-drive file=`test_image_name 1`$(set_qcow2_l2_cache `test_image_name 1`),if=none,format=qcow2,id=fs_filter${DRIVE_CACHE_OPTION}
+                          -device ide-hd,drive=fs_filter,serial=${CLIENT_NUM}0${UNIQUE_ID}"
        ;;
     serial)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"

--- a/run_hck_studio.sh
+++ b/run_hck_studio.sh
@@ -39,7 +39,7 @@ fi
 
 ${QEMU_BIN} \
     ${QEMU_RUN_AS} \
-    -drive file=${STUDIO_IMAGE},if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
+    -drive file=${STUDIO_IMAGE}$(set_qcow2_l2_cache ${STUDIO_IMAGE}),if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
     -device ide-hd,drive=ide_${UNIQUE_ID},serial=${UID_FIRST}${UNIQUE_ID} \
     ${WORLD_NET_DEVICE} \
     ${CTRL_NET_DEVICE} \


### PR DESCRIPTION
Setting a sufficient amount of L2 cache when using QCOW2 images can improve the performance significantly. The default cache size is enough to cover 8 GB of an image with the default cluster size of 64 KB. Since practically all the images used with VirtHCK are larger than that, this can be a bottleneck for performance. Hear an option is added to cover the entire virtual size of QCOW2 images. The memory overhead is not big: for example, to cover a 100 GB image with 64 KB cluster size, a mere 12.5 MB of RAM will be used for L2 cache.

More details on that here:
http://git.qemu.org/?p=qemu.git;a=blob;f=docs/qcow2-cache.txt

Previous application of this patch caused an error in the case of storage testing, because test images were created after their properties were supposed to be probed (#15). Now this is fixed.