### PR TITLE
viocrypt: Add virtio-crypto-pci device for testing

### DIFF
--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -48,6 +48,7 @@ TEST_DEV_TYPE="network"      TEST_DEV_NAME="virtio-net-pci"      TEST_DEV_EXTRA_
 #TEST_DEV_TYPE="usb3"         TEST_DEV_NAME="usb-storage"         TEST_DEV_EXTRA_PARAMS=""
 #TEST_DEV_TYPE="ivshmem"      TEST_DEV_NAME="ivshmem-doorbell"    TEST_DEV_EXTRA_PARAMS=""
 #TEST_DEV_TYPE="video"
+#TEST_DEV_TYPE="viocrypt"     TEST_DEV_NAME="virtio-crypto-pci"   TEST_DEV_EXTRA_PARAMS=""
 
 #Test device: virtual or physical
 #Set IS_PYHSICAL to true if the test device is physical.

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -325,6 +325,10 @@ if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
     video)
        BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
         ;;
+    viocrypt)
+       BOOT_STORAGE_PAIR="${IDE_STORAGE_PAIR}"
+       TEST_VIOCRYPT_DEVICE="-object cryptodev-backend-builtin,id=cryptodev0 -device ${TEST_DEV_NAME},id=crypto0,cryptodev=cryptodev0"
+       ;;
 
       * )
        echo "NOT IMPLEMENTED"
@@ -371,6 +375,7 @@ ${QEMU_BIN} \
         ${TEST_BALLOON_DEVICE} \
         ${TEST_IVSHMEM_DEVICE} \
         ${TEST_RNG_DEVICE} \
+        ${TEST_VIOCRYPT_DEVICE} \
         ${WORLD_NET_IFACE} \
         ${MACHINE_UUID} \
         -machine ${MACHINE_TYPE} \


### PR DESCRIPTION
Add the option to add a virtio-crypto-pci device so that
the viocrypt driver can be tested.