### PR TITLE
Adding support for specifying virtio-net device linkspeed

### DIFF
--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -134,6 +134,9 @@ ENABLE_S4=on
 BIOS_CLIENT1=$BIOS_CLIENT
 BIOS_CLIENT2=$BIOS_CLIENT
 
+#Virtio-net device speed
+#VIRTIONET_SPEED=100000
+
 #Set remote viewers (VNC) title postfix for setup VMs
 TITLE_POSTFIX=`pwd`
 

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -79,6 +79,14 @@ usb_cmd()
     fi
 }
 
+virtionet_speed()
+{
+    if [ ! -z "${VIRTIONET_SPEED}" ]
+    then
+        echo ",speed=${VIRTIONET_SPEED}"
+    fi
+}
+
 extra_params_cmd()
 {
     if [ ! -z "${TEST_DEV_EXTRA_PARAMS}" ]
@@ -256,7 +264,7 @@ if [ "$IS_PHYSICAL" = "false" ]; then    # in case of a virtual device
           ;;
        esac
        TEST_NET_DEVICES="${TAP_DEVICE}
-                         -device ${TEST_DEV_NAME}`extra_params_cmd`,netdev=hostnet2,mac=${TEST_NET_MAC_ADDRESS},bus=${BUS_NAME}.0$(client_mq_device_param)${TEST_DEVICE_ID}"
+                         -device ${TEST_DEV_NAME}`extra_params_cmd``virtionet_speed`,netdev=hostnet2,mac=${TEST_NET_MAC_ADDRESS},bus=${BUS_NAME}.0$(client_mq_device_param)${TEST_DEVICE_ID}"
        ;;
     bootstorage)
        BOOT_STORAGE_PAIR="-drive file=`image_name`$(set_qcow2_l2_cache `image_name`),if=none,id=vio_block${DRIVE_CACHE_OPTION}


### PR DESCRIPTION
A recent patch in QEMU intrudeced virtio-net device linkspeed:
https://github.com/qemu/qemu/commit/9473939ed7addcaaeb8fde5c093918fb7fa0919c

With this commit linkspeed could be updated with the `hck_setup.cfg` file under `VIRTIONET_SPEED`

since this feature is only available in newer versions of qemu it will be disabled as default.

Signed-off-by: Lior Haim <lior@daynix.com>