### PR TITLE
Do not turn off TX offloads on tap device

### DIFF
--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -244,7 +244,10 @@ enslave_test_iface() {
      ;;
   esac
 
+if [ -d "$TAP_TX_OFF" ] && [ "$TAP_TX_OFF" == "yes" ]
+then
   ethtool -K ${IFNAME} tx off
+fi
   ifconfig ${IFNAME} txqueuelen $(queue_len_tx $CLIENT1_N_QUEUES $CLIENT1_N_QUEUES)
 }
 

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -123,6 +123,7 @@ CLIENT_WORLD_ACCESS=off  # Turn on ONLY for activation purposes!
 
 #MISC
 VHOST_STATE=on
+TAP_TX_OFF=no
 SNAPSHOT=off
 ENLIGHTENMENTS_STATE=off
 #OPT_CPU_FLAGS=",+ssse3,+sse4.1,+sse4.2"  # Optional extra flags for CPU


### PR DESCRIPTION
Network device under test is configured to suppress it's TX
offload capabilities. Effectively this disables GRO.
Latest check shows that at the moment there is no problem
to use GRO during HCK tests that check RSC functionality.
Current commit makes TX offload suppression configurable and
does not use it by default. If will be needed for specific
tests, this can be done per test and should be documented.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>