### PR TITLE
Adding an option for disabling bridge netfilter

### DIFF
--- a/hck.sh
+++ b/hck.sh
@@ -232,6 +232,8 @@ elif  [ "$CI_MODE" = true ] ; then
   fi
 else
 
+  disable_bridge_nf
+
   echo Creating bridges...
   create_bridges
 

--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -359,3 +359,13 @@ kill_ivshmem_server() {
     sudo kill ${cat ${IVSHMEM_PID}}
   fi
 }
+
+disable_bridge_nf() {
+  if [ "$DISABLE_BRIDGE_NF" = "on" ]
+  then
+    echo Disabling bridge-netfilter...
+    sysctl net.bridge.bridge-nf-call-arptables=0 > /dev/null
+    sysctl net.bridge.bridge-nf-call-ip6tables=0 > /dev/null
+    sysctl net.bridge.bridge-nf-call-iptables=0 > /dev/null
+  fi
+}

--- a/hck_setup.cfg
+++ b/hck_setup.cfg
@@ -126,6 +126,7 @@ VHOST_STATE=on
 TAP_TX_OFF=no
 SNAPSHOT=off
 ENLIGHTENMENTS_STATE=off
+DISABLE_BRIDGE_NF=on
 #OPT_CPU_FLAGS=",+ssse3,+sse4.1,+sse4.2"  # Optional extra flags for CPU
 VCPU_MODEL=13  # For example: 13 = Dothan, 26 = Nehalem, 58 = IvyBridge
 ENABLE_S3=on


### PR DESCRIPTION
This option will verify before each hck run the following setting on bridge netfilters:
```
net.bridge.bridge-nf-call-ip6tables = 0
net.bridge.bridge-nf-call-iptables = 0
net.bridge.bridge-nf-call-arptables = 0
```
This option is enabled by default and can be configured with DISABLE_BRIDGE_NF=on/off

Signed-off-by: Lior Haim <lior@daynix.com>