### PR TITLE
client: last nibble of MAC address must differ between test and support

### DIFF
--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -44,7 +44,7 @@ client_test_mac()
 {
   DEVICE_NUM=$1
 
-  echo 56:${UID_FIRST}:${UID_SECOND}:0${CLIENT_NUM}:0${DEVICE_NUM}:cc
+  echo 56:${UID_FIRST}:${UID_SECOND}:0${CLIENT_NUM}:0${DEVICE_NUM}:c${CLIENT_NUM}
 }
 
 client_cpus()


### PR DESCRIPTION
At least RSC test of WLK (8.1) during the test suppresses
address randomisation and only last nibble of MAC is taken
in account when calculating automatic IP address, i.e it
is always 169.254.1.<last_byte_of_MAC>. As a result both
test and support adapter have the same IP address and the
test can't execute. It looks like there is no case when
this change shall break something.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>