### PR TITLE
Fix clients dumps

### DIFF
--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -314,8 +314,8 @@ Setup configuration
   Snapshot mode.............. ${SNAPSHOT}
 END
 
-  if [ $RUN_CLIENT1 ] ; then dump_client "1" ; fi
-  if [ $RUN_CLIENT2 ] ; then dump_client "2" ; fi
+  if [ $RUN_CLIENT1 ] || [ $RUN_ALL ] ; then dump_client "1" ; fi
+  if [ $RUN_CLIENT2 ] || [ $RUN_ALL ] ; then dump_client "2" ; fi
 }
 
 LOOPRUN_FILE=${HCK_ROOT}"/.hck_stop_looped_vms_${UNIQUE_ID}.flag"

--- a/hck_aux.sh
+++ b/hck_aux.sh
@@ -300,7 +300,6 @@ Setup configuration
   Test device extra config... ${EXTRA_PARAMS}
   Graphics................... ${VIDEO_TYPE}
   Test network backend....... ${TEST_NET_TYPE}
-  Studio VM display port..... Vnc ${STUDIO_PORT}/$(( ${STUDIO_PORT} + 5900 )) Telnet ${STUDIO_TELNET_PORT}
   QEMU binary................ ${QEMU_BIN}
   Studio VM image............ ${STUDIO_IMAGE}
   SMB share on host.......... ${SHARE_ON_HOST}
@@ -312,6 +311,7 @@ Setup configuration
   S3 enabled..................${ENABLE_S3}
   S4 enabled..................${ENABLE_S4}
   Snapshot mode.............. ${SNAPSHOT}
+  Studio VM display port..... Vnc ${STUDIO_PORT}/$(( ${STUDIO_PORT} + 5900 )) Telnet ${STUDIO_TELNET_PORT}
 END
 
   if [ $RUN_CLIENT1 ] || [ $RUN_ALL ] ; then dump_client "1" ; fi


### PR DESCRIPTION
Clients dumps weren't showing when running without any flag.
Also moved the studio vnc port line to the bottom next to the clients ports.