### PR TITLE
Adding -pidfile option for ci-mode

### DIFF
--- a/hck.sh
+++ b/hck.sh
@@ -140,6 +140,10 @@ case $key in
     echo FILESYSTEM_TESTS_IMAGE=$2 >> $ARGS_CFG
     shift
     ;;
+    -pidfile)
+    echo PID_FILE=$2 >> $ARGS_CFG
+    shift
+    ;;
     st)
     RUN_STUDIO=true
     ;;

--- a/run_hck_client.sh
+++ b/run_hck_client.sh
@@ -182,6 +182,14 @@ log_cmd()
     fi
 }
 
+pid_file()
+{
+    if [ ! -z "${PID_FILE}" ]
+    then
+        echo "-pidfile ${PID_FILE}"
+    fi
+}
+
 #Machine type related difference
 case $MACHINE_TYPE in
     q35 )
@@ -394,7 +402,7 @@ ${QEMU_BIN} \
         -global kvm-pit.lost_tick_policy=discard -rtc base=localtime,clock=host,driftfix=slew \
         -global ${DISABLE_S3_PARAM}=${S3_DISABLE_OPTION} -global ${DISABLE_S4_PARAM}=${S4_DISABLE_OPTION} \
         -name HCK-Client${CLIENT_NUM}_${UNIQUE_ID}_`hostname`_${TITLE_POSTFIX} \
-        `cdrom_cmd` `bios_cmd` \
+        `cdrom_cmd` `bios_cmd` `pid_file` \
         `graphics_cmd` `monitor_cmd` ${SNAPSHOT_OPTION} `usb_cmd` `extra_cmd` \
         `trace_cmd` \
          2>&1 | `log_cmd`

--- a/run_hck_studio.sh
+++ b/run_hck_studio.sh
@@ -37,6 +37,15 @@ if [ "${DISABLE_UUIDS}" != "true" ]; then
 STUDIO_UUID="-uuid ${UNIQUE_ID}127c-8795-4e67-95da-8dd0a8891cd1"
 fi
 
+pid_file()
+{
+    if [ ! -z "${PID_FILE}" ]
+    then
+        echo "-pidfile ${PID_FILE}"
+    fi
+}
+
+
 ${QEMU_BIN} \
     ${QEMU_RUN_AS} \
     -drive file=${STUDIO_IMAGE}$(set_qcow2_l2_cache ${STUDIO_IMAGE}),if=none,id=ide_${UNIQUE_ID}${DRIVE_CACHE_OPTION} \
@@ -48,6 +57,6 @@ ${QEMU_BIN} \
     -cpu qemu64,+x2apic,+fsgsbase${OPT_CPU_FLAGS} \
     ${STUDIO_UUID} \
     -name HCK-Studio_${UNIQUE_ID}_`hostname`_${TITLE_POSTFIX} \
-    -rtc base=localtime \
+    -rtc base=localtime `pid_file` \
     ${GRAPHICS_STUDIO} ${MONITOR_STUDIO} ${SNAPSHOT_OPTION} ${STUDIO_EXTRA}
 


### PR DESCRIPTION
-pidfile takes the path of the wanted file for the studio and clients
machines QEMU PIDs to be written to.
example usage: sudo ./hck.sh ci-mode ... -pidfile /tmp/pids

this will write the PIDs to file /tmp/pids

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>